### PR TITLE
fix minify proguard rules

### DIFF
--- a/lib/araw-proguard-rules.pro
+++ b/lib/araw-proguard-rules.pro
@@ -1,0 +1,43 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+-keep class com.kirkbushman.auth.models.** {*;}
+-keep class com.kirkbushman.auth.http.** {*;}
+
+-keep class com.kirkbushman.araw.models.** {*;}
+-keep class com.kirkbushman.araw.http.** {*;}
+
+-keepattributes *Annotation*, Signature, Exception
+
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+ -keep,allowobfuscation,allowshrinking interface retrofit2.Call
+ -keep,allowobfuscation,allowshrinking class retrofit2.Response
+ -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# https://stackoverflow.com/questions/77143071/r8-and-proguard-missing-class-error-in-data-class-that-is-using-keep-annotatio
+-dontwarn java.lang.invoke.StringConcatFactory
+
+# OkHttp platform used only on JVM and when Conscrypt and other security providers are available.
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,6 +21,17 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildTypes {
+        release {
+            minifyEnabled true
+            consumerProguardFiles 'araw-proguard-rules.pro'
+        }
+        debug {
+            minifyEnabled false
+            consumerProguardFiles 'araw-proguard-rules.pro'
+        }
+    }
+
     compileOptions {
         sourceCompatibility java_target
         targetCompatibility java_target
@@ -28,6 +39,8 @@ android {
 
     kotlinOptions {
         jvmTarget = jvm_target
+        // see https://github.com/Kotlin/kotlinx.serialization/issues/2145
+        freeCompilerArgs = ["-Xstring-concat=inline"]
     }
 }
 


### PR DESCRIPTION
Fix proguard rules so that we can enable minify.

In my small app this has reduced the apk size from 6.11MB to 3.27MB